### PR TITLE
Fixing problem with empty captions (python's None in dictionary)

### DIFF
--- a/instaLooter/core.py
+++ b/instaLooter/core.py
@@ -493,8 +493,10 @@ class InstaLooter(object):
                 return medias_queued, True
         return medias_queued, False
 
-    def _add_sidecars_to_queue(self, media, condition, media_count, medias_queued, new_only):
-        media = self.get_post_info(media.get('shortcode') or media['code'])
+    def _add_sidecars_to_queue(self, media0, condition, media_count, medias_queued, new_only):
+        media = self.get_post_info(media0.get('shortcode') or media0['code'])
+        if 'caption' in media0 and media0['caption']:
+            media.setdefault('caption', media0['caption'])
         for sidecar in media['edge_sidecar_to_children']['edges']:
             sidecar = self._sidecar_to_media(sidecar['node'], media)
             medias_queued, stop = self._add_media_to_queue(
@@ -573,7 +575,7 @@ class InstaLooter(object):
     @staticmethod
     def _sidecar_to_media(sidecar, media):
         for key in ("owner", "caption", "location"):
-            sidecar.setdefault(key, media.get(key))
+            sidecar.setdefault(key, media.get(key) if key in media and media.get(key) else "")
         sidecar['likes'] = media['edge_media_preview_like']['count']
         sidecar['comments'] = media['edge_media_to_comment']['count']
         sidecar['display_src'] = sidecar['display_url']


### PR DESCRIPTION
1. For pictures in multi-picture posts the method "get_post_info" (loading description for code) seem not to have access to the caption from the enclosing post. What I solved by copying the nonempty caption from the parent "media".
2. I've stumbled upon a post without the caption (None in dictionary) so to avoid a runtime error I changed the code to return empty string in such a case.

Sample error message from the problem solved:
Downloading | 66%(  4 of 6)|##########     |Elapsed Time: 0:00:01 |ETA: 0:00:00Exception in thread Thread-4:
Traceback (most recent call last):
  File "/XXX/bin/bin-anaconda3/envs/insta-looter/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/XXX/instaLooter/worker.py", line 47, in run
    self._download_photo(media)
  File "/XXX/instaLooter/worker.py", line 97, in _download_photo
    self._add_metadata(photo_name, media)
  File "/XXX/instaLooter/worker.py", line 81, in _add_metadata
    piexif.ExifIFD.UserComment: metadata.get('caption', '').encode('utf-8'),
AttributeError: 'NoneType' object has no attribute 'encode'