### PR TITLE
Use minimal url but keep at least the first url path component "hphotos-ak-xfa1"

### DIFF
--- a/instaLooter/worker.py
+++ b/instaLooter/worker.py
@@ -22,7 +22,7 @@ except ImportError:
 
 class InstaDownloader(threading.Thread):
 
-    _SANITIZING_RX = re.compile(r'(https://.*?/).*(/.*\.jpg)')
+    _SANITIZING_RX = re.compile(r'(https://.*?/.*?/).*(/.*\.jpg)')
 
     def __init__(self, owner):
         super(InstaDownloader, self).__init__()


### PR DESCRIPTION
First url component should be included at least instead of trimming the whole path otherwise the url will be invalid. Currently this first path component is "hphotos-ak-xfa1".
This should fix #64. Related to 1405bdffc248b81597d7abcfbeee3f6495cf32eb 