### PR TITLE
Added cookie handling, so no more instagram login lockouts

### DIFF
--- a/instaLooter/core.py
+++ b/instaLooter/core.py
@@ -22,6 +22,8 @@ import bs4 as bs
 
 from .worker import InstaDownloader
 from .utils import get_times
+from .utils import save_cookies
+from .utils import load_cookies
 
 PARSER = 'html.parser'
 
@@ -111,6 +113,7 @@ class InstaLooter(object):
         self.jobs = jobs
 
         self.session = requests.Session()
+        load_cookies(self.session, 'cookies.txt')
         self.csrftoken = None
         self.user_agent = ("Mozilla/5.0 (Windows NT 10.0; WOW64; "  # seems legit
                            "rv:50.0) Gecko/20100101 Firefox/50.0")
@@ -180,6 +183,7 @@ class InstaLooter(object):
         login = self.session.post(self.URL_LOGIN, data=login_post, allow_redirects=True)
         self.session.headers.update({'X-CSRFToken': login.cookies['csrftoken']})
         self.csrftoken = login.cookies['csrftoken']
+        save_cookies(self.session, 'cookies.txt')
 
         if login.status_code != 200:
             self.csrftoken = None

--- a/instaLooter/utils.py
+++ b/instaLooter/utils.py
@@ -10,9 +10,30 @@ import warnings
 import datetime
 import dateutil.relativedelta
 import hues
+import requests.cookies
 
 console = hues.SimpleConsole(stdout=sys.stderr)
 
+def save_cookies(session, filename):
+    if not os.path.isdir(os.path.dirname(filename)):
+        return False
+    with open(filename, 'w') as f:
+        f.truncate()
+        pickle.dump(session.cookies._cookies, f)
+
+
+def load_cookies(session, filename):
+    if not os.path.isfile(filename):
+        return False
+
+    with open(filename) as f:
+        cookies = pickle.load(f)
+        if cookies:
+            jar = requests.cookies.RequestsCookieJar()
+            jar._cookies = cookies
+            session.cookies = jar
+        else:
+            return False
 
 def get_times(timeframe):
     if timeframe is None:


### PR DESCRIPTION
I verified by performing a login with one call... and then performing another call without the login information.  This was on a user who is private.  You may wish to change the cookie file location handling or whatever - but this gives me a LOT of happiness.