### PR TITLE
Feature/add support for customizing download url

### DIFF
--- a/instaLooter/core.py
+++ b/instaLooter/core.py
@@ -64,7 +64,7 @@ class InstaLooter(object):
 
     def __init__(self, directory=None, profile=None, hashtag=None,
                 add_metadata=False, get_videos=False, videos_only=False,
-                jobs=16, template="{id}"):
+                jobs=16, template="{id}", custom_photo_url=None):
         """Create a new looter instance.
 
         Keyword Arguments:
@@ -106,6 +106,8 @@ class InstaLooter(object):
 
         self.template = template
         self._required_template_keys = self._RX_TEMPLATE.findall(template)
+
+        self._custom_photo_url = custom_photo_url
 
         self.directory = directory
         self.add_metadata = add_metadata

--- a/instaLooter/worker.py
+++ b/instaLooter/worker.py
@@ -27,6 +27,7 @@ class InstaDownloader(threading.Thread):
     def __init__(self, owner):
         super(InstaDownloader, self).__init__()
         self.medias = owner._medias_queue
+        self.photo_url_generator = owner._custom_photo_url or self._default_url_generator
         self.directory = owner.directory
         self.add_metadata = owner.add_metadata
         self.owner = owner
@@ -87,7 +88,11 @@ class InstaDownloader(threading.Thread):
     def _download_photo(self, media):
         """Download a picture from a media dictionnary.
         """
-        photo_url = ''.join(self._SANITIZING_RX.search(media['display_src']).groups())
+        photo_url = self.photo_url_generator(media)
+
+        if not isinstance(photo_url, six.string_types):
+            raise ValueError('The "custom_photo_url" option must return a string !')
+
         photo_name = os.path.join(self.directory, self.owner._make_filename(media))
 
         # save full-resolution photo
@@ -128,6 +133,14 @@ class InstaDownloader(threading.Thread):
                 for block in res.iter_content(1024):
                     if block:
                         dest_file.write(block)
+
+    def _default_url_generator(self, media):
+        """Default photo URL generator.
+
+        This method strips out any width and height specifications.
+        """
+        
+        return ''.join(self._SANITIZING_RX.search(media['display_src']).groups())
 
     def kill(self):
         """Kill the Thread.

--- a/instaLooter/worker.py
+++ b/instaLooter/worker.py
@@ -139,7 +139,6 @@ class InstaDownloader(threading.Thread):
 
         This method strips out any width and height specifications.
         """
-        
         return ''.join(self._SANITIZING_RX.search(media['display_src']).groups())
 
     def kill(self):

--- a/tests/test_instaLooter.py
+++ b/tests/test_instaLooter.py
@@ -35,12 +35,12 @@ class TestInstaLooterProfileDownload(unittest.TestCase):
 
         def _test(self):
             looter = instaLooter.InstaLooter(self.tmpdir, profile=profile, get_videos=True)
-            looter.download(media_count=10)
+            looter.download(media_count=200)
 
             # We have to use GreaterEqual since multi media posts
             # are counted as 1 but will download more than one
             # picture / video
-            self.assertGreaterEqual(len(os.listdir(self.tmpdir)), min(10, int(looter.metadata['media']['count'])))
+            self.assertGreaterEqual(len(os.listdir(self.tmpdir)), min(200, int(looter.metadata['media']['count'])))
             self.assertEqual(profile, looter.metadata['username'])
 
         setattr(cls, "test_{}".format(profile), _test)

--- a/tests/test_instaLooter.py
+++ b/tests/test_instaLooter.py
@@ -35,12 +35,12 @@ class TestInstaLooterProfileDownload(unittest.TestCase):
 
         def _test(self):
             looter = instaLooter.InstaLooter(self.tmpdir, profile=profile, get_videos=True)
-            looter.download(media_count=200)
+            looter.download(media_count=10)
 
             # We have to use GreaterEqual since multi media posts
             # are counted as 1 but will download more than one
             # picture / video
-            self.assertGreaterEqual(len(os.listdir(self.tmpdir)), min(200, int(looter.metadata['media']['count'])))
+            self.assertGreaterEqual(len(os.listdir(self.tmpdir)), min(10, int(looter.metadata['media']['count'])))
             self.assertEqual(profile, looter.metadata['username'])
 
         setattr(cls, "test_{}".format(profile), _test)
@@ -111,7 +111,6 @@ class TestInstaLooterUtils(unittest.TestCase):
         self.assertEqual(squareenix['username'], 'squareenix')
         self.assertEqual(squareenix['id'], '2117884847')
         self.assertFalse(squareenix['is_private'])
-
 
 
 def load_tests(loader, tests, pattern):


### PR DESCRIPTION
# Reason
I needed to grab images with certain aspect ratios. So I added the option of passing in a function to customize from which URL to download the image.

## Examples
#### Using lambdas (and to grab other image sources from media object)
```python
looter = InstaLooter( directory="Desktop/", ... , custom_photo_url=lambda media: media['thumbnail_src'])
```

#### Grab custom image size (as in examples)
```python
def custom_photo_url(media):
  cleaning_regex = re.compile(r"(s[0-9x]*/)?(e[0-9]*)/")
  return cleaning_regex.sub('s320x320/', media['display_src'])

looter = InstaLooter( directory="thumbnails/", ... , custom_photo_url=custom_photo_url)
```

#### Create a custom cropped image
```python
def square_photo_url(media):
  cleaning_regex = re.compile(r"(s[0-9x]*/)?(e[0-9]*)/")
  dims = media['dimensions']

  smaller_dim, y_offset, x_offset = "", 0, 0
  if media['height'] > media['width']:
    smaller_dim = str(media["width"])
    y_offset = (media['height'] - media['width'])/2
  else:
    smaller_dim = str(media["height"])
    x_offset = (media['width'] - media['height'])/2

  crop_url_params = 'c{}.{}.{}.{}/'.format( str(x_offset), str(y_offset), smaller_dim, smaller_dim)
  return cleaning_regex.sub( crop_url_params, media['display_src'])

looter = InstaLooter( directory="square_images/", ... , custom_photo_url=square_photo_url)
```