### PR TITLE
Fix typo in cli.py

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -147,7 +147,7 @@ Template
 --------
 
 The default filename of the pictures and videos on Instagram doesn't show
-anything about the file you just downloaded. But using the ``-t`` argument
+anything about the file you just downloaded. But using the ``-T`` argument
 allows you to give instaLooter a filename template, using the following
 format with brackets-enclosed (``{}``) variable names among:
 

--- a/instaLooter/cli.py
+++ b/instaLooter/cli.py
@@ -61,7 +61,7 @@ Options - Miscellaneous:
 
 Template:
     The default filename of the pictures and videos on Instagram doesn't show
-    anything about the file you just downloaded. But using the -t argument
+    anything about the file you just downloaded. But using the -T argument
     allows you to give instaLooter a filename template, using the following
     format with brackets-enclosed ({}) variable names among:
     - ``id``*² and ``code``² of the instagram id of the media

--- a/instaLooter/core.py
+++ b/instaLooter/core.py
@@ -90,7 +90,7 @@ class InstaLooter(object):
                 format. See the the Template page of the documentation
                 for available keys. **[default: {id}]
             url_generator (`function`): a callable that takes a media
-                dictionnary as argument and returs the URL it should
+                dictionary as argument and returs the URL it should
                 download the picture from. The default tries to get
                 the best available size. **[default: `urlgen.default`]**
             dump_json (`bool`): Save each resource metadata to a

--- a/instaLooter/worker.py
+++ b/instaLooter/worker.py
@@ -108,7 +108,7 @@ class InstaDownloader(threading.Thread):
                 img.save(path, exif=piexif.dump(exif_dict))
 
     def _download_photo(self, media):
-        """Download a picture from a media dictionnary.
+        """Download a picture from a media dictionary.
         """
         photo_url = self.owner.url_generator(media)
 
@@ -129,7 +129,7 @@ class InstaDownloader(threading.Thread):
             self._save_metadata(photo_name, media)
 
     def _download_video(self, media):
-        """Download a video from a media dictionnary.
+        """Download a video from a media dictionary.
         """
         url = "https://www.instagram.com/p/{}/".format(media.get('shortcode') or media['code'])
 


### PR DESCRIPTION
The cli.py file had a typo in the comments.
The line
_'[...] the **-t** argument allows you to give instaLooter a filename template [...]'_
should read
_'[...] the **-T** argument allows you to give instaLooter a filename template [...]'_