### PR TITLE
Feature: Set the dowloaded file filesystem modification time

### DIFF
--- a/instaLooter/worker.py
+++ b/instaLooter/worker.py
@@ -31,6 +31,8 @@ class InstaDownloader(threading.Thread):
         path = re.sub('\..{3}$', '.json', path)
         with open(path, 'w') as fp:
             json.dump(metadata, fp, indent=4, sort_keys=True)
+        # set file modification and access time to be the ones when posting to instagram
+        os.utime( path, (metadata["date"], metadata["date"]))  
 
     @staticmethod
     def _get_caption(metadata):
@@ -120,6 +122,8 @@ class InstaDownloader(threading.Thread):
         # save full-resolution photo
         if not self.dump_only:
             self._dl(photo_url, photo_name)
+            # set file modification and access time to be the ones when posting to instagram
+            os.utime( photo_name, (media["date"], media["date"]))  
 
         # put info from Instagram post into image metadata
         if self.add_metadata:
@@ -127,6 +131,8 @@ class InstaDownloader(threading.Thread):
 
         if self.dump_json:
             self._save_metadata(photo_name, media)
+
+
 
     def _download_video(self, media):
         """Download a video from a media dictionary.
@@ -147,6 +153,9 @@ class InstaDownloader(threading.Thread):
         # save video
         if not self.dump_only:
             self._dl(video_url, video_name)
+            # set file modification and access time to be the ones when posting to instagram
+            os.utime( photo_name, (media["date"], media["date"]))  
+
 
         if self.dump_json:
             self._save_metadata(video_name, media)

--- a/instaLooter/worker.py
+++ b/instaLooter/worker.py
@@ -154,7 +154,7 @@ class InstaDownloader(threading.Thread):
         if not self.dump_only:
             self._dl(video_url, video_name)
             # set file modification and access time to be the ones when posting to instagram
-            os.utime( photo_name, (media["date"], media["date"]))  
+            os.utime( video_name, (media["date"], media["date"]))  
 
 
         if self.dump_json:


### PR DESCRIPTION
Hi!

I am using certain program to handle my photos, and the program sorts the pictures according to their modification time. Now "as it is" the instalooter (that worked otherwise perfectly!) gives the files the time of the download, and that does not work with my setup.

here is short pull request that would make the files created to have modification time according to the instagram post. I though of putting it behind an commandline "enable" but adding that would make the edit quite much larger, and i do not see why it could not be the default action.

Cheers,
Pauli
