### PR TITLE
Update looters.py - IDs of length ten also allowed

### DIFF
--- a/instalooter/looters.py
+++ b/instalooter/looters.py
@@ -743,7 +743,7 @@ class PostLooter(InstaLooter):
     """
 
     _RX_URL = re.compile(
-        r'(?:https?://)?(?:www\.instagram\.com|instagr\.am)/p/([0-9a-zA-Z_\-]{11})'
+        r'(?:https?://)?(?:www\.instagram\.com|instagr\.am)/p/([0-9a-zA-Z_\-]{10,11})'
     )
 
     _RX_CODE = re.compile(

--- a/instalooter/looters.py
+++ b/instalooter/looters.py
@@ -747,7 +747,7 @@ class PostLooter(InstaLooter):
     )
 
     _RX_CODE = re.compile(
-        r'^[0-9a-zA-Z_\-]{11}$'
+        r'^[0-9a-zA-Z_\-]{10,11}$'
     )
 
     def __init__(self, code, **kwargs):

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -109,7 +109,7 @@ class TestResolvedIssues(unittest.TestCase):
         for f in self.destfs.scandir("/"):
             self.assertTrue(f.name.startswith('nintendo.'))
 
-    @unittest.skipIf(os.getenv("CI") is None, "need private user account")
+    @unittest.skipIf(os.getenv("IG_USERNAME") is None, "need private user account")
     def test_issue_006(self):
         """
         Checks that instalooter does not iterate forever on a private


### PR DESCRIPTION
Changed the regex for Post IDs to allow for IDs of ten or eleven.
This is needed for older posts which did not yet use IDs of lengths > 10.

Closes https://github.com/althonos/InstaLooter/issues/214