### PR TITLE
zero padding datetime fields for lexicographic sort to be natural.

### DIFF
--- a/instalooter/_utils.py
+++ b/instalooter/_utils.py
@@ -42,8 +42,8 @@ class NameGenerator(object):
         timestamp = media.get('date') or media.get('taken_at_timestamp')
         if timestamp is not None:
             dt = datetime.datetime.fromtimestamp(timestamp)
-            info['datetime'] = ("{0.year}-{0.month}-{0.day} {0.hour}"
-                "h{0.minute}m{0.second}s{0.microsecond}").format(dt)
+            info['datetime'] = ("{0.year}-{0.month:02d}-{0.day:02d} {0.hour:02d}"
+                "h{0.minute:02d}m{0.second:02d}s{0.microsecond}").format(dt)
             info['date'] = datetime.date.fromtimestamp(timestamp)
 
         return dict(six.moves.filter(


### PR DESCRIPTION
Dates and times when using `-T` and `{datetime}` look like this `2019-1-1 2h3m4s`.

In GUI file explorers and image viewers this _might_ be sorted chronologically, if they implement natural sort.

If the date looked like this `2019-01-01 02h03m04s`, then normal string sorting would also get them in the right order (and not - January, October, February... etc).