### PR TITLE
Remove deprecated extended_dump option

### DIFF
--- a/docs/source/batch.rst
+++ b/docs/source/batch.rst
@@ -79,8 +79,6 @@ Each section can be given the same parameters as the command line:
   set to *True* to dump metadata in JSON format
 ``dump-only``
   set to *True* to only dump metadata, not downloading anything.
-``extended-dump``
-  set to *True* to fetch additional information when dumping metadata.
 
 For instance, to download 3 new videos from ``#funny`` and ``#nsfw``:
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -117,10 +117,6 @@ Options - Metadata
 ``-D, --dump-only``
   Save only the metadata and no video / picture.
 
-``-e, --extended-dump``
-  Always dump the maximum amount of extractable information, at the cost
-  of more time.
-
 
 Options - Miscellaneous
 -----------------------

--- a/instalooter/batch.py
+++ b/instalooter/batch.py
@@ -161,7 +161,6 @@ class BatchRunner(object):
                             template=self._get(section_id, 'template', '{id}'),
                             dump_json=self._getboolean(section_id, 'dump-json', False),
                             dump_only=self._getboolean(section_id, 'dump-only', False),
-                            extended_dump=self._getboolean(section_id, 'extended-dump', False),
                             session=session)
 
                         if self.parser.has_option(section_id, 'username'):

--- a/instalooter/cli/__init__.py
+++ b/instalooter/cli/__init__.py
@@ -143,7 +143,6 @@ def main(argv=None, stream=None):
                 template=args['--template'],
                 dump_json=args['--dump-json'],
                 dump_only=args['--dump-only'],
-                extended_dump=args['--extended-dump']
             )
 
             # Attempt to login and extract the timeframe

--- a/instalooter/cli/constants.py
+++ b/instalooter/cli/constants.py
@@ -62,8 +62,6 @@ HELP = textwrap.dedent(
                                      downloaded videos/pictures.
         -D, --dump-only              Save only the metadata and no video/picture.
                                      Implies `--dump-json`.
-        -e, --extended-dump          Always dump the maximum amount of extracted
-                                     information, at the cost of more time.
 
     Options - Miscellaneous:
         -l LEVEL, --loglevel LEVEL   The level of log to produce, as an

--- a/instalooter/looters.py
+++ b/instalooter/looters.py
@@ -236,7 +236,6 @@ class InstaLooter(object):
                  template="{id}",       # type: Text
                  dump_json=False,       # type: bool
                  dump_only=False,       # type: bool
-                 extended_dump=False,   # type: bool
                  session=None           # type: Optional[Session]
                  ):
         # type: (...) -> None
@@ -258,10 +257,6 @@ class InstaLooter(object):
                 JSON file next to the actual image/video.
             dump_only (bool): Only save metadata and discard the actual
                 resource.
-            extended_dump (bool): Attempt to fetch as much metadata as
-                possible, at the cost of more time. Set to `True` if, for
-                instance, you always want the top comments to be downloaded
-                in the dump.
             session (~requests.Session or None): a `requests` session,
                 or `None` to create a new one.
 
@@ -273,7 +268,6 @@ class InstaLooter(object):
         self.namegen = NameGenerator(template)
         self.dump_only = dump_only
         self.dump_json = dump_json or dump_only
-        self.extended_dump = extended_dump
         self.session = self._init_session(session)
         atexit.register(self.session.close)
 

--- a/tests/test_looter.py
+++ b/tests/test_looter.py
@@ -157,33 +157,6 @@ class TestPostLooter(unittest.TestCase):
 #                 dump = json.load(f)
 #             self.assertMediaEqual(media, dump)
 #
-#     def test_extended_dump(self):
-#         looter = instaLooter.InstaLooter(
-#             self.tmpdir,
-#             profile="instagram",
-#             dump_only=True,
-#             extended_dump=True,
-#         )
-#         test_medias = list(itertools.islice(
-#             (m for m in looter.medias() if not m['is_video']), 3))
-#         looter.download(media_count=3)
-#
-#         # Check all files were downloaded as expected
-#         self.assertEqual(
-#             sorted(os.listdir(self.tmpdir)),
-#             sorted(str("{}.json").format(media['id']) for media in test_medias)
-#         )
-#
-#         # Check the metadata are OK
-#         for media in test_medias:
-#             with open(os.path.join(self.tmpdir, "{}.json").format(media['id'])) as f:
-#                 dump = json.load(f)
-#             self.assertMediaEqual(media, dump)
-#
-#             # Check the dump was "extended"
-#             self.assertIn('edge_media_to_comment', dump)
-#             self.assertIn('edge_media_to_caption', dump)
-#
 #
 # class TestUtils(_TempTestCase):
 #


### PR DESCRIPTION
Resolves #265 

Extended dump was made obsolete by the change to GraphQL and is no longer useful. The variable is not used outside of being assigned. 