### PR TITLE
Update login schema

### DIFF
--- a/instalooter/looters.py
+++ b/instalooter/looters.py
@@ -126,7 +126,8 @@ class InstaLooter(object):
         headers = copy.deepcopy(session.headers)
         homepage = "https://www.instagram.com/"
         login_url = "https://www.instagram.com/accounts/login/ajax/"
-        data = {'username': username, 'password': password}
+        enc_password = "#PWD_INSTAGRAM_BROWSER:0:{}:{}".format(time.time(), password)
+        data = {'username': username, 'enc_password': enc_password}
 
         try:
             session.headers.update({


### PR DESCRIPTION
Fix the login payload, ~~apparently the old schema is now rejected~~ (EDIT: it isn't). See https://github.com/althonos/InstaLooter/issues/287#issuecomment-630456522. For more info, see also https://github.com/instaloader/instaloader/pull/623. Original bugfix by @pgrimaud https://github.com/pgrimaud/instagram-user-feed/commit/96ad4cf.