### PR TITLE
Support resuming iteration from saved end_cursor.  Implements #226 (WIP)

### DIFF
--- a/instalooter/cli/__init__.py
+++ b/instalooter/cli/__init__.py
@@ -168,6 +168,7 @@ def main(argv=None, stream=None):
                 destination=dest_fs,
                 media_count=args['--num-to-dl'],
                 timeframe=args['--time'],
+                cursor=args['--cursor'],
                 new_only=args['--new'],
                 pgpbar_cls=None if args['--quiet'] else TqdmProgressBar,
                 dlpbar_cls=None if args['--quiet'] else TqdmProgressBar)

--- a/instalooter/cli/constants.py
+++ b/instalooter/cli/constants.py
@@ -54,6 +54,7 @@ HELP = textwrap.dedent(
                                      in the destination directory (faster).
         -t TIME, --time TIME         The time limit within which to download
                                      pictures and video (see *Time*).
+        -c CURSOR, --cursor CURSOR   Use saved cursor to resume looting
 
     Options - Metadata:
         -m, --add-metadata           Add date and caption metadata to downloaded

--- a/instalooter/looters.py
+++ b/instalooter/looters.py
@@ -320,7 +320,7 @@ class InstaLooter(object):
             return TimedMediasIterator(pages_iterator, timeframe)
         return MediasIterator(pages_iterator)
 
-    def medias(self, timeframe=None):
+    def medias(self, timeframe=None, cursor=None):
         # type: (Optional[_Timeframe]) -> Iterator[Dict[Text, Any]]
         """Obtain an iterator over the Instagram medias.
 
@@ -331,7 +331,7 @@ class InstaLooter(object):
             MediasIterator: an iterator over the medias in every pages.
 
         """
-        return self._medias(self.pages(), timeframe)
+        return self._medias(self.pages(cursor=cursor), timeframe)
 
     def get_post_info(self, code):
         # type: (str) -> dict
@@ -409,6 +409,7 @@ class InstaLooter(object):
                  condition=None,        # type: Optional[Callable[[dict], bool]]
                  media_count=None,      # type: Optional[int]
                  timeframe=None,        # type: Optional[_Timeframe]
+                 cursor=None,           # type: Optional[str]
                  new_only=False,        # type: bool
                  pgpbar_cls=None,       # type: Optional[Type[ProgressBar]]
                  dlpbar_cls=None,       # type: Optional[Type[ProgressBar]]
@@ -432,6 +433,7 @@ class InstaLooter(object):
             timeframe (tuple or None): a tuple of two `~datetime.datetime`
                 objects to enforce a time frame (the first item must be
                 more recent). Leave to `None` to ignore times.
+            cursor (str or none): a cursor used to resume looting
             new_only (bool): stop media discovery when already
                 downloaded medias are encountered.
             pgpbar_cls (type or None): an optional `~.pbar.ProgressBar`
@@ -450,7 +452,7 @@ class InstaLooter(object):
         destination, close_destination = self._init_destfs(destination)
 
         # Create an iterator over the pages with an optional progress bar
-        pages_iterator = self.pages()   # type: Iterable[Dict[Text, Any]]
+        pages_iterator = self.pages(cursor=cursor)   # type: Iterable[Dict[Text, Any]]
         pages_iterator = pgpbar = self._init_pbar(pages_iterator, pgpbar_cls)
 
         # Create an iterator over the medias

--- a/instalooter/looters.py
+++ b/instalooter/looters.py
@@ -708,7 +708,7 @@ class ProfileLooter(InstaLooter):
         self._username = username
         self._owner_id = None
 
-    def pages(self):
+    def pages(self, cursor=None):
         # type: () -> ProfileIterator
         """Obtain an iterator over Instagram post pages.
 
@@ -723,10 +723,10 @@ class ProfileLooter(InstaLooter):
 
         """
         if self._owner_id is None:
-            it = ProfileIterator.from_username(self._username, self.session)
+            it = ProfileIterator.from_username(self._username, self.session, cursor=cursor)
             self._owner_id = it.owner_id
             return it
-        return ProfileIterator(self._owner_id, self.session, self.rhx)
+        return ProfileIterator(self._owner_id, self.session, self.rhx, cursor=cursor)
 
 
 class HashtagLooter(InstaLooter):


### PR DESCRIPTION
* Adds a `cursor` argument to the `pages()` method to begin iteration using a stored `end_cursor` from a previous request.
* Adds a `-c` / `--cursor` command-line argument to support downloading beginning at a given `end_cursor` value.

The latter isn't particularly useful yet without a way to either display cursors in the downloader output or better yet save them to the cache directory, but it demonstrates the functionality.

This is a work in progress, but I figured I'd show what I have now to see if it merits merging with some additional documentation and polish.