### PR TITLE
Set timeout on UserAgentRequestHandler.queue.get()

### DIFF
--- a/instalooter/_uadetect.py
+++ b/instalooter/_uadetect.py
@@ -55,7 +55,10 @@ def get_user_agent(port=None, cache=None):
     # Use webbrowser to connect to the server with the default browser
     webbrowser.open("http://localhost:{}/".format(port))
     # Wait for the request handler to get the request from the browser
-    user_agent = UserAgentRequestHandler.queue.get()
+    try:
+        user_agent = UserAgentRequestHandler.queue.get(timeout=5)
+    except queue.Empty:
+        user_agent = None
     # Close the server
     server.shutdown()
     server.server_close()


### PR DESCRIPTION
This fixes InstaLooter on machines without installed web browsers,
such as the environment in which GitHub Actions run.