### PR TITLE
Bump coloredlogs and tenacity versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,14 +32,14 @@ python_requires = >= 2.7, != 3.0.*, != 3.1.*, != 3.2.*, != 3.5.1
 packages = find:
 test_suite = tests
 install_requires =
-    coloredlogs ~=14.0
+    coloredlogs ~=15.0
     python-dateutil ~=2.1
     docopt ~=0.4
     fs ~=2.1
     requests ~=2.18
     six ~=1.4
     tqdm ~=4.19
-    tenacity ~=6.0
+    tenacity ~=8.0
     typing ~=3.6    ; python_version < '3.6'
     verboselogs ~=1.7
 tests_require =


### PR DESCRIPTION
This fixes #293 
I've tested downloading user, hashtag and post and it works. Exact library versions I have are tenacity 8.0.1 and coloredlogs 15.0.1